### PR TITLE
fixed inefficient render() for 'raw' render mode

### DIFF
--- a/gym_sokoban/envs/sokoban_env.py
+++ b/gym_sokoban/envs/sokoban_env.py
@@ -223,12 +223,12 @@ class SokobanEnv(gym.Env):
     def render(self, mode='human', close=None, scale=1):
         assert mode in RENDERING_MODES
 
-        img = self.get_image(mode, scale)
-
         if 'rgb_array' in mode:
+            img = self.get_image(mode, scale)
             return img
 
         elif 'human' in mode:
+            img = self.get_image(mode, scale)
             from gym.envs.classic_control import rendering
             if self.viewer is None:
                 self.viewer = rendering.SimpleImageViewer()


### PR DESCRIPTION
the line: `img = self.get_image(mode, scale)` does not need to be called when working with the 'raw' render mode. this makes it faster.